### PR TITLE
feat: add jwt register and login endpoints

### DIFF
--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -3,23 +3,31 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "dependencies": {
-    "express": "^4.19.2",
-    "http-proxy-middleware": "^3.0.0",
-    "swagger-ui-express": "^4.7.0",
-    "cors": "^2.8.5",
-    "helmet": "^7.0.0",
-    "morgan": "^1.10.0",
-    "winston": "^3.10.0",
-    "@genesisnet/env": "0.0.1",
-    "@genesisnet/activity-log": "0.0.1"
-  },
-  "devDependencies": {
-    "@types/express": "^4.17.21",
-    "@types/http-proxy-middleware": "^2.0.6",
-    "@types/swagger-ui-express": "^4.1.6",
-    "@types/cors": "^2.8.17",
-    "@types/morgan": "^1.9.4",
-    "@types/helmet": "^4.0.0"
+    "dependencies": {
+      "express": "^4.19.2",
+      "http-proxy-middleware": "^3.0.0",
+      "swagger-ui-express": "^4.7.0",
+      "cors": "^2.8.5",
+      "helmet": "^7.0.0",
+      "morgan": "^1.10.0",
+      "winston": "^3.10.0",
+      "@genesisnet/env": "0.0.1",
+      "@genesisnet/activity-log": "0.0.1",
+      "bcryptjs": "^2.4.3",
+      "@genesisnet/utils": "0.0.1"
+    },
+    "devDependencies": {
+      "@types/express": "^4.17.21",
+      "@types/http-proxy-middleware": "^2.0.6",
+      "@types/swagger-ui-express": "^4.1.6",
+      "@types/cors": "^2.8.17",
+      "@types/morgan": "^1.9.4",
+      "@types/helmet": "^4.0.0",
+      "vitest": "^1.3.1",
+      "supertest": "^6.3.3",
+      "@types/supertest": "^2.0.12"
+    },
+    "scripts": {
+      "test": "vitest"
+    }
   }
-}

--- a/api-gateway/src/__tests__/auth.test.ts
+++ b/api-gateway/src/__tests__/auth.test.ts
@@ -1,0 +1,59 @@
+import request from "supertest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+
+let app: any;
+let clearUsers: () => void;
+
+beforeAll(async () => {
+  process.env.DB_URL = "http://localhost";
+  process.env.REDIS_URL = "http://localhost";
+  process.env.JWT_SECRET = "test";
+  process.env.NODE_ENV = "test";
+  const mod = await import("../index");
+  app = mod.app;
+  clearUsers = mod.clearUsers;
+});
+
+beforeEach(() => {
+  clearUsers();
+});
+
+describe("auth", () => {
+  it("registers a user", async () => {
+    const res = await request(app)
+      .post("/api/auth/register")
+      .send({ email: "a@test.com", password: "pass" });
+    expect(res.status).toBe(201);
+  });
+
+  it("prevents duplicate registration", async () => {
+    await request(app)
+      .post("/api/auth/register")
+      .send({ email: "a@test.com", password: "pass" });
+    const res = await request(app)
+      .post("/api/auth/register")
+      .send({ email: "a@test.com", password: "pass" });
+    expect(res.status).toBe(400);
+  });
+
+  it("logs in a user", async () => {
+    await request(app)
+      .post("/api/auth/register")
+      .send({ email: "a@test.com", password: "pass" });
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ email: "a@test.com", password: "pass" });
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toBeDefined();
+  });
+
+  it("rejects invalid password", async () => {
+    await request(app)
+      .post("/api/auth/register")
+      .send({ email: "a@test.com", password: "pass" });
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ email: "a@test.com", password: "wrong" });
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,5 +2,9 @@
   "name": "@genesisnet/utils",
   "version": "0.0.1",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "@genesisnet/env": "0.0.1",
+    "jsonwebtoken": "^9.0.2"
+  }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,1 +1,1 @@
-export const placeholder = true;
+export * from "./jwt";

--- a/packages/utils/src/jwt.ts
+++ b/packages/utils/src/jwt.ts
@@ -1,0 +1,15 @@
+import jwt from "jsonwebtoken";
+import { env } from "@genesisnet/env";
+
+const SECRET = env.JWT_SECRET;
+
+export const signJwt = (
+  payload: object,
+  options?: jwt.SignOptions
+): string => {
+  return jwt.sign(payload, SECRET, { expiresIn: "1h", ...options });
+};
+
+export const verifyJwt = <T>(token: string): T => {
+  return jwt.verify(token, SECRET) as T;
+};


### PR DESCRIPTION
## Summary
- add jwt sign/verify helper
- implement /api/auth/register and /api/auth/login with bcrypt password hashing
- add authGuard middleware and dummy protected route
- basic unit tests for register and login

## Testing
- `pnpm install` (fails: Proxy response (403) !== 200 when HTTP Tunneling)
- `pnpm --filter api-gateway test` (fails: Proxy response (403) !== 200 when HTTP Tunneling)


------
https://chatgpt.com/codex/tasks/task_e_689cb8ae2058832ea8e805af49b4b8a7