### PR TITLE
feat: add express API gateway facade with CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 API_GATEWAY_PORT=3000
 NODE_ENV=development
+DASHBOARD_SVC_URL=http://localhost:4001
+DATA_SVC_URL=http://localhost:4002
+NETWORK_SVC_URL=http://localhost:4003
+TX_SVC_URL=http://localhost:4004
+REPUTATION_SVC_URL=http://localhost:4005

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -6,6 +6,11 @@ const schema = z.object({
   API_GATEWAY_PORT: z.coerce.number().default(3000),
   METRICS_PORT: z.coerce.number().default(9100),
   SEARCH_PORT: z.coerce.number().default(3001),
+  DASHBOARD_SVC_URL: z.string().url().default('http://localhost:4001'),
+  DATA_SVC_URL: z.string().url().default('http://localhost:4002'),
+  NETWORK_SVC_URL: z.string().url().default('http://localhost:4003'),
+  TX_SVC_URL: z.string().url().default('http://localhost:4004'),
+  REPUTATION_SVC_URL: z.string().url().default('http://localhost:4005'),
 });
 
 export const env = schema.parse(process.env);

--- a/packages/svc-api-gateway/package.json
+++ b/packages/svc-api-gateway/package.json
@@ -14,7 +14,9 @@
   "dependencies": {
     "@genesisnet/env": "^0.1.0",
     "dotenv": "^17.2.1",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "http-proxy-middleware": "^2.0.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.23",

--- a/packages/svc-api-gateway/src/index.ts
+++ b/packages/svc-api-gateway/src/index.ts
@@ -1,18 +1,75 @@
 import 'dotenv/config'; // load .env
-import express from 'express';
+import express, { Request, Response, NextFunction } from 'express';
+import cors from 'cors';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+import { env } from '@genesisnet/env';
 
 const app = express();
-const PORT = Number(process.env.API_GATEWAY_PORT || 3000);
+const PORT = env.API_GATEWAY_PORT;
 
 // basic middlewares
+app.use(cors());
 app.use(express.json());
 
 // health & ready checks
 app.get('/health', (_req, res) => res.json({ ok: true, service: 'api-gateway' }));
 app.get('/ready', (_req, res) => res.json({ ready: true }));
 
+// proxy routes
+app.use(
+  '/api/dashboard',
+  createProxyMiddleware({
+    target: env.DASHBOARD_SVC_URL,
+    changeOrigin: true,
+    pathRewrite: { '^/api/dashboard': '' },
+  }),
+);
+
+app.use(
+  '/api/data',
+  createProxyMiddleware({
+    target: env.DATA_SVC_URL,
+    changeOrigin: true,
+    pathRewrite: { '^/api/data': '' },
+  }),
+);
+
+app.use(
+  '/api/network',
+  createProxyMiddleware({
+    target: env.NETWORK_SVC_URL,
+    changeOrigin: true,
+    pathRewrite: { '^/api/network': '' },
+  }),
+);
+
+app.use(
+  '/api/tx',
+  createProxyMiddleware({
+    target: env.TX_SVC_URL,
+    changeOrigin: true,
+    pathRewrite: { '^/api/tx': '' },
+  }),
+);
+
+app.use(
+  '/api/reputation',
+  createProxyMiddleware({
+    target: env.REPUTATION_SVC_URL,
+    changeOrigin: true,
+    pathRewrite: { '^/api/reputation': '' },
+  }),
+);
+
 // 404 fallback
 app.use((_req, res) => res.status(404).json({ error: 'Not Found' }));
+
+// error middleware
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal Server Error' });
+});
 
 // start
 app.listen(PORT, () => {

--- a/packages/svc-api-gateway/src/types.d.ts
+++ b/packages/svc-api-gateway/src/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'cors';


### PR DESCRIPTION
## Summary
- add service URL env vars
- expose API Gateway routes forwarding to dashboard, data, network, tx and reputation services with CORS and error handling
- stub cors module types

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*
- `npm test`
- `npm run -w @genesisnet/svc-api-gateway check` *(fails: TS2307: Cannot find module 'http-proxy-middleware')*


------
https://chatgpt.com/codex/tasks/task_e_68adb733d954832eba75d95f57be4b3b