### PR TITLE
feat(api-gateway): add proxy routes with cors

### DIFF
--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -10,6 +10,7 @@ const schema = z.object({
   BLOCKCHAIN_PORT: z.coerce.number().default(4003),
   WS_PORT: z.coerce.number().default(3002),
   NETWORK_PORT: z.coerce.number().default(4004),
+  REPUTATION_PORT: z.coerce.number().default(4005),
   TX_PREFIX: z.string().default('TX'),
   DATABASE_URL: z.string().url().default('postgres://postgres:postgres@postgres:5432/genesisnet'),
   REDIS_URL: z.string().url().default('redis://redis:6379/0'),

--- a/packages/svc-api-gateway/package.json
+++ b/packages/svc-api-gateway/package.json
@@ -14,7 +14,9 @@
   "dependencies": {
     "@genesisnet/env": "^0.1.0",
     "express": "^4.19.2",
-    "@genesisnet/common": "^0.1.0"
+    "@genesisnet/common": "^0.1.0",
+    "cors": "^2.8.5",
+    "http-proxy-middleware": "^2.0.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.23",

--- a/packages/svc-api-gateway/src/index.ts
+++ b/packages/svc-api-gateway/src/index.ts
@@ -1,4 +1,6 @@
-import express from 'express';
+import express, { Request, Response, NextFunction } from 'express';
+import cors from 'cors';
+import { createProxyMiddleware } from 'http-proxy-middleware';
 import { env } from '@genesisnet/env';
 import { logger, requestId } from '@genesisnet/common';
 
@@ -6,12 +8,42 @@ const app = express();
 const log = logger.child({ service: 'api-gateway' });
 
 app.use(requestId(log));
+app.use(cors());
 app.use(express.json());
 
 app.get('/health', (req, res) => res.json({ ok: true, service: 'api-gateway' }));
 app.get('/ready', (req, res) => res.json({ ready: true }));
 
+// proxy routes to internal services
+const proxies = [
+  { path: '/api/dashboard', target: `http://localhost:${env.METRICS_PORT}` },
+  { path: '/api/data', target: `http://localhost:${env.SEARCH_PORT}` },
+  { path: '/api/network', target: `http://localhost:${env.NETWORK_PORT}` },
+  { path: '/api/tx', target: `http://localhost:${env.TX_PORT}` },
+  { path: '/api/reputation', target: `http://localhost:${env.REPUTATION_PORT}` },
+];
+
+proxies.forEach(({ path, target }) => {
+  app.use(
+    path,
+    createProxyMiddleware({
+      target,
+      changeOrigin: true,
+      pathRewrite: { [`^${path}`]: '' },
+      logLevel: 'warn',
+    }),
+  );
+});
+
+// 404 handler
 app.use((req, res) => res.status(404).json({ error: 'Not Found' }));
+
+// generic error handler
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
+  log.error({ err }, 'unhandled error');
+  res.status(500).json({ error: 'Internal Server Error' });
+});
 
 app.listen(env.API_GATEWAY_PORT, () => {
   log.info(`listening on http://localhost:${env.API_GATEWAY_PORT}`);


### PR DESCRIPTION
## Summary
- expose gateway facade routing to internal services
- enable CORS and add generic error handler
- add REPUTATION_PORT env variable

## Testing
- `npm test`
- `npm run -w @genesisnet/svc-api-gateway test`
- `npm run -w @genesisnet/svc-api-gateway check` *(fails: Cannot find module 'cors' or its corresponding type declarations)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68adba0471b8832eae69c84a6d4535a8