### PR TITLE
feat(search): add basic catalog CRUD

### DIFF
--- a/packages/svc-search/src/data.ts
+++ b/packages/svc-search/src/data.ts
@@ -1,39 +1,37 @@
-export type Item = {
+export type Provider = {
   id: string;
-  title: string;
-  content: string;
-  tags: string[];
+  name: string;
 };
 
-export const DATA: Item[] = [
-  {
-    id: '1',
-    title: 'AI Agent Market',
-    content: 'Autonomous agents on-chain',
-    tags: ['ai', 'agent', 'icp'],
-  },
-  {
-    id: '2',
-    title: 'GenesisNet Metrics',
-    content: 'Prometheus + Grafana wiring',
-    tags: ['metrics', 'prometheus'],
-  },
-  {
-    id: '3',
-    title: 'Search Service Stub',
-    content: 'In-memory search prototype',
-    tags: ['search', 'stub'],
-  },
-  {
-    id: '4',
-    title: 'ICP Ledger',
-    content: 'Wallet and transaction flow',
-    tags: ['icp', 'ledger', 'tx'],
-  },
-  {
-    id: '5',
-    title: 'Gateway Routing',
-    content: 'API Gateway routes and auth',
-    tags: ['gateway', 'routing'],
-  },
-];
+export type DataPackage = {
+  id: string;
+  providerId: string;
+  name: string;
+  description: string;
+};
+
+export type User = {
+  id: string;
+  username: string;
+  email: string;
+};
+
+export const providers: Provider[] = [];
+export const dataPackages: DataPackage[] = [];
+export const users: User[] = [];
+
+let providerId = 1;
+let dataPackageId = 1;
+let userId = 1;
+
+export function nextProviderId(): string {
+  return String(providerId++);
+}
+
+export function nextDataPackageId(): string {
+  return String(dataPackageId++);
+}
+
+export function nextUserId(): string {
+  return String(userId++);
+}

--- a/packages/svc-search/src/index.ts
+++ b/packages/svc-search/src/index.ts
@@ -1,17 +1,34 @@
 import express from 'express';
 import { env } from '@genesisnet/env';
 import { logger, requestId } from '@genesisnet/common';
-import { DATA } from './data.js';
+import {
+  providers,
+  dataPackages,
+  users,
+  nextProviderId,
+  nextDataPackageId,
+  nextUserId,
+} from './data.js';
 
 const app = express();
 const log = logger.child({ service: 'search' });
 const PORT = env.SEARCH_PORT;
 
 app.use(requestId(log));
+app.use(express.json());
 
 app.get('/health', (req, res) => {
   res.json({ ok: true, service: 'search' });
 });
+
+function searchItems(q: string) {
+  const haystack = [
+    ...providers.map((p) => ({ type: 'provider', ...p })),
+    ...dataPackages.map((d) => ({ type: 'data_package', ...d })),
+    ...users.map((u) => ({ type: 'user', ...u })),
+  ];
+  return haystack.filter((item) => Object.values(item).join(' ').toLowerCase().includes(q));
+}
 
 app.get('/search', (req, res) => {
   const q = String(req.query.q ?? '')
@@ -20,11 +37,151 @@ app.get('/search', (req, res) => {
   if (!q) {
     return res.json({ query: q, count: 0, results: [] });
   }
-  const results = DATA.filter((item) => {
-    const hay = (item.title + ' ' + item.content + ' ' + item.tags.join(' ')).toLowerCase();
-    return hay.includes(q);
-  });
+  const results = searchItems(q);
   res.json({ query: q, count: results.length, results });
+});
+
+// Provider CRUD
+app.get('/providers', (req, res) => {
+  res.json(providers);
+});
+
+app.post('/providers', (req, res) => {
+  const { name } = req.body;
+  if (!name) {
+    return res.status(400).json({ error: 'name required' });
+  }
+  const provider = { id: nextProviderId(), name };
+  providers.push(provider);
+  res.status(201).json(provider);
+});
+
+app.get('/providers/:id', (req, res) => {
+  const provider = providers.find((p) => p.id === req.params.id);
+  if (!provider) {
+    return res.sendStatus(404);
+  }
+  res.json(provider);
+});
+
+app.put('/providers/:id', (req, res) => {
+  const provider = providers.find((p) => p.id === req.params.id);
+  if (!provider) {
+    return res.sendStatus(404);
+  }
+  if (req.body.name) {
+    provider.name = req.body.name;
+  }
+  res.json(provider);
+});
+
+app.delete('/providers/:id', (req, res) => {
+  const idx = providers.findIndex((p) => p.id === req.params.id);
+  if (idx === -1) {
+    return res.sendStatus(404);
+  }
+  const [provider] = providers.splice(idx, 1);
+  res.json(provider);
+});
+
+// Data package CRUD
+app.get('/data-packages', (req, res) => {
+  res.json(dataPackages);
+});
+
+app.post('/data-packages', (req, res) => {
+  const { providerId, name, description } = req.body;
+  if (!providerId || !name) {
+    return res.status(400).json({ error: 'providerId and name required' });
+  }
+  const dataPackage = {
+    id: nextDataPackageId(),
+    providerId,
+    name,
+    description: description ?? '',
+  };
+  dataPackages.push(dataPackage);
+  res.status(201).json(dataPackage);
+});
+
+app.get('/data-packages/:id', (req, res) => {
+  const dataPackage = dataPackages.find((d) => d.id === req.params.id);
+  if (!dataPackage) {
+    return res.sendStatus(404);
+  }
+  res.json(dataPackage);
+});
+
+app.put('/data-packages/:id', (req, res) => {
+  const dataPackage = dataPackages.find((d) => d.id === req.params.id);
+  if (!dataPackage) {
+    return res.sendStatus(404);
+  }
+  if (req.body.name) {
+    dataPackage.name = req.body.name;
+  }
+  if (req.body.description !== undefined) {
+    dataPackage.description = req.body.description;
+  }
+  if (req.body.providerId) {
+    dataPackage.providerId = req.body.providerId;
+  }
+  res.json(dataPackage);
+});
+
+app.delete('/data-packages/:id', (req, res) => {
+  const idx = dataPackages.findIndex((d) => d.id === req.params.id);
+  if (idx === -1) {
+    return res.sendStatus(404);
+  }
+  const [dataPackage] = dataPackages.splice(idx, 1);
+  res.json(dataPackage);
+});
+
+// User CRUD
+app.get('/users', (req, res) => {
+  res.json(users);
+});
+
+app.post('/users', (req, res) => {
+  const { username, email } = req.body;
+  if (!username) {
+    return res.status(400).json({ error: 'username required' });
+  }
+  const user = { id: nextUserId(), username, email: email ?? '' };
+  users.push(user);
+  res.status(201).json(user);
+});
+
+app.get('/users/:id', (req, res) => {
+  const user = users.find((u) => u.id === req.params.id);
+  if (!user) {
+    return res.sendStatus(404);
+  }
+  res.json(user);
+});
+
+app.put('/users/:id', (req, res) => {
+  const user = users.find((u) => u.id === req.params.id);
+  if (!user) {
+    return res.sendStatus(404);
+  }
+  if (req.body.username) {
+    user.username = req.body.username;
+  }
+  if (req.body.email !== undefined) {
+    user.email = req.body.email;
+  }
+  res.json(user);
+});
+
+app.delete('/users/:id', (req, res) => {
+  const idx = users.findIndex((u) => u.id === req.params.id);
+  if (idx === -1) {
+    return res.sendStatus(404);
+  }
+  const [user] = users.splice(idx, 1);
+  res.json(user);
 });
 
 app.get('/', (req, res) => {

--- a/packages/svc-search/tsconfig.json
+++ b/packages/svc-search/tsconfig.json
@@ -9,7 +9,12 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@genesisnet/env": ["../env/src/index.ts"],
+      "@genesisnet/common": ["../common/src/index.ts"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add in-memory provider, data package, and user stores
- expose CRUD endpoints for catalog entities and search across them
- configure TypeScript paths for local package resolution

## Testing
- `npm test`
- `npm run lint`
- `npm run -w @genesisnet/svc-search build` *(fails: Cannot find module '@genesisnet/env' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68adc2fe6bcc832e8a2798b265801d72