### PR TITLE
feat(ws): add socket.io service with redis events

### DIFF
--- a/packages/svc-ws/package.json
+++ b/packages/svc-ws/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "express": "^4.19.2",
-    "ws": "^8.18.0",
+    "socket.io": "^4.7.5",
+    "@socket.io/redis-adapter": "^8.2.1",
+    "redis": "^4.6.13",
     "zod": "^3.23.8",
     "@genesisnet/env": "^0.1.0",
     "@genesisnet/common": "^0.1.0"
@@ -19,7 +21,6 @@
   "devDependencies": {
     "@types/express": "^4.17.23",
     "@types/node": "^20.19.11",
-    "@types/ws": "^8.18.1",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }


### PR DESCRIPTION
## Summary
- replace native ws server with Socket.IO
- forward Redis pub/sub messages (metrics, activity, network, search) to clients

## Testing
- `npm test`
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68add9e0eae0832ea87e1b85055fa3fa