### PR TITLE
feat: add dashboard and network APIs

### DIFF
--- a/packages/svc-api-gateway/src/index.ts
+++ b/packages/svc-api-gateway/src/index.ts
@@ -16,20 +16,20 @@ app.get('/ready', (req, res) => res.json({ ready: true }));
 
 // proxy routes to internal services
 const proxies = [
-  { path: '/api/dashboard', target: `http://localhost:${env.METRICS_PORT}` },
+  { path: '/api/dashboard', target: `http://localhost:${env.METRICS_PORT}`, rewrite: '/dashboard' },
   { path: '/api/data', target: `http://localhost:${env.SEARCH_PORT}` },
   { path: '/api/network', target: `http://localhost:${env.NETWORK_PORT}` },
   { path: '/api/tx', target: `http://localhost:${env.TX_PORT}` },
   { path: '/api/reputation', target: `http://localhost:${env.REPUTATION_PORT}` },
 ];
 
-proxies.forEach(({ path, target }) => {
+proxies.forEach(({ path, target, rewrite }) => {
   app.use(
     path,
     createProxyMiddleware({
       target,
       changeOrigin: true,
-      pathRewrite: { [`^${path}`]: '' },
+      pathRewrite: { [`^${path}`]: rewrite ?? '' },
       logLevel: 'warn',
     }),
   );


### PR DESCRIPTION
## Summary
- expose dashboard metrics and logs endpoints
- add network topology endpoint
- support dashboard path rewrite in API gateway

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ade0fbdb30832eb8854e3b4c5ee531