### PR TITLE
feat: add network scan

### DIFF
--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -11,6 +11,10 @@ const schema = z.object({
   WS_PORT: z.coerce.number().default(3002),
   NETWORK_PORT: z.coerce.number().default(4004),
   REPUTATION_PORT: z.coerce.number().default(4005),
+  NETWORK_DISCOVERY_URL: z
+    .string()
+    .url()
+    .default('http://localhost:4943/nodes'),
   TX_PREFIX: z.string().default('TX'),
   DATABASE_URL: z.string().url().default('postgres://postgres:postgres@postgres:5432/genesisnet'),
   REDIS_URL: z.string().url().default('redis://redis:6379/0'),

--- a/packages/svc-network/src/index.ts
+++ b/packages/svc-network/src/index.ts
@@ -1,5 +1,7 @@
 import http from 'node:http';
+import { randomUUID } from 'node:crypto';
 import knex from 'knex';
+import { createClient } from 'redis';
 import { env } from '@genesisnet/env';
 import { logger, logActivity } from '@genesisnet/common';
 
@@ -10,6 +12,8 @@ const db = knex({
   client: 'pg',
   connection: env.DATABASE_URL,
 });
+
+const redis = createClient({ url: env.REDIS_URL });
 
 const server = http.createServer((req, res) => {
   if (req.method === 'GET' && req.url === '/health') {
@@ -26,11 +30,75 @@ const server = http.createServer((req, res) => {
     req.on('end', async () => {
       try {
         const metadata = body ? JSON.parse(body) : {};
-        await logActivity('SCAN', metadata).catch((err) =>
-          log.error({ err }, 'activity log failed'),
+
+        let discovered: string[] = [];
+        try {
+          const resp = await fetch(env.NETWORK_DISCOVERY_URL);
+          if (resp.ok) {
+            const data = (await resp.json()) as { nodes?: unknown };
+            if (Array.isArray(data.nodes)) {
+              discovered = data.nodes.filter((n): n is string => typeof n === 'string');
+            }
+          }
+        } catch (err) {
+          log.error({ err }, 'discovery fetch failed');
+        }
+
+        const rows = await db('network_nodes').select('id', 'address');
+        const existing = new Map(rows.map((r) => [r.address, r.id]));
+        const addresses = new Set<string>([...discovered, ...existing.keys()]);
+
+        const results: {
+          id: string;
+          address: string;
+          latency_ms: number | null;
+          is_online: boolean;
+        }[] = [];
+        const newNodes: string[] = [];
+
+        for (const address of addresses) {
+          const id = existing.get(address) ?? randomUUID();
+          const url = address.replace(/\/$/, '') + '/health';
+          const start = Date.now();
+          let latency: number | null = null;
+          let isOnline = false;
+          try {
+            const pingRes = await fetch(url);
+            if (pingRes.ok) {
+              latency = Date.now() - start;
+              isOnline = true;
+            }
+          } catch {}
+
+          if (existing.has(address)) {
+            await db('network_nodes')
+              .where({ id })
+              .update({
+                latency_ms: latency,
+                is_online: isOnline,
+                updated_at: db.fn.now(),
+              });
+          } else {
+            await db('network_nodes').insert({
+              id,
+              address,
+              latency_ms: latency,
+              is_online: isOnline,
+            });
+            newNodes.push(address);
+          }
+
+          results.push({ id, address, latency_ms: latency, is_online: isOnline });
+        }
+
+        await redis.publish('network_update', JSON.stringify({ nodes: results }));
+
+        await logActivity('SCAN', { ...metadata, discovered: newNodes.length }).catch(
+          (err) => log.error({ err }, 'activity log failed'),
         );
+
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true }));
+        res.end(JSON.stringify({ ok: true, nodes: results }));
       } catch (err) {
         log.error({ err }, 'scan failed');
         res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -59,6 +127,14 @@ const server = http.createServer((req, res) => {
   res.end();
 });
 
-server.listen(PORT, () => {
-  log.info(`listening on port ${PORT}`);
+async function start() {
+  await redis.connect();
+  server.listen(PORT, () => {
+    log.info(`listening on port ${PORT}`);
+  });
+}
+
+start().catch((err) => {
+  log.error({ err }, 'failed to start network service');
+  process.exit(1);
 });

--- a/packages/svc-network/tsconfig.json
+++ b/packages/svc-network/tsconfig.json
@@ -1,8 +1,12 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   },
   "include": ["src"]
 }
+


### PR DESCRIPTION
## Summary
- extend env with NETWORK_DISCOVERY_URL
- implement network scan endpoint to ping nodes and publish topology updates

## Testing
- `npm test`
- `npm run -w @genesisnet/env build` *(fails: module issues)*
- `npm run -w @genesisnet/svc-network build` *(fails: module issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ade272a7d0832ebe4451913f46288d