### PR TITLE
feat: add scheduler service for periodic scan and metrics recompute

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ BLOCKCHAIN_PORT=4003
 WS_PORT=3002
 NETWORK_PORT=4004
 
+# Scheduler
+SCHEDULER_SCAN_INTERVAL_MS=30000
+SCHEDULER_METRICS_INTERVAL_MS=60000
+
 # Database and cache
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/genesisnet
 REDIS_URL=redis://redis:6379/0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,22 @@ services:
     ports:
       - "${NETWORK_PORT:-4004}:4004"
 
+  scheduler:
+    image: node:20-alpine
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+      - /workspace/node_modules
+      - /workspace/packages/svc-scheduler/node_modules
+    env_file:
+      - .env
+    command: sh -c "npm i && npm run -w @genesisnet/svc-scheduler dev"
+    depends_on:
+      - network
+      - metrics
+      - postgres
+      - redis
+
 volumes:
   pgdata:
   redisdata:

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -11,6 +11,8 @@ const schema = z.object({
   WS_PORT: z.coerce.number().default(3002),
   NETWORK_PORT: z.coerce.number().default(4004),
   REPUTATION_PORT: z.coerce.number().default(4005),
+  SCHEDULER_SCAN_INTERVAL_MS: z.coerce.number().default(30000),
+  SCHEDULER_METRICS_INTERVAL_MS: z.coerce.number().default(60000),
   NETWORK_DISCOVERY_URL: z
     .string()
     .url()

--- a/packages/svc-scheduler/package.json
+++ b/packages/svc-scheduler/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@genesisnet/svc-scheduler",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "@genesisnet/env": "^0.1.0",
+    "@genesisnet/common": "^0.1.0",
+    "knex": "^2.5.1",
+    "redis": "^4.6.13"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.11",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/svc-scheduler/src/index.ts
+++ b/packages/svc-scheduler/src/index.ts
@@ -1,0 +1,74 @@
+import knex from 'knex';
+import { createClient } from 'redis';
+import { env } from '@genesisnet/env';
+import { logger } from '@genesisnet/common';
+
+const log = logger.child({ service: 'scheduler' });
+
+const SCAN_INTERVAL = env.SCHEDULER_SCAN_INTERVAL_MS;
+const METRICS_INTERVAL = env.SCHEDULER_METRICS_INTERVAL_MS;
+
+const db = knex({
+  client: 'pg',
+  connection: env.DATABASE_URL,
+});
+
+const redis = createClient({ url: env.REDIS_URL });
+
+async function runScan() {
+  try {
+    await fetch(`http://localhost:${env.NETWORK_PORT}/scan`, { method: 'POST' });
+    log.info('network scan triggered');
+  } catch (err) {
+    log.error({ err }, 'network scan trigger failed');
+  }
+}
+
+async function getMetrics() {
+  const [{ count: txCountRaw }] = await db('transactions')
+    .where('created_at', '>=', db.raw("now() - interval '1 minute'"))
+    .count<{ count: string }>("* as count");
+
+  const [{ avg: avgPriceRaw }] = await db('transactions').avg<{ avg: string | null }>(
+    'amount as avg',
+  );
+
+  const [{ count: nodesOnlineRaw }] = await db('network_nodes')
+    .where({ is_online: true })
+    .count<{ count: string }>("* as count");
+
+  const [{ total: totalRaw }] = await db('transactions').count<{ total: string }>("* as total");
+  const [{ paid: paidRaw }] = await db('transactions')
+    .where({ status: 'paid' })
+    .count<{ paid: string }>("* as paid");
+
+  return {
+    txPerMin: Number(txCountRaw ?? 0),
+    avgPrice: Number(avgPriceRaw ?? 0),
+    nodesOnline: Number(nodesOnlineRaw ?? 0),
+    offerRate: totalRaw ? Number(paidRaw) / Number(totalRaw) : 0,
+  };
+}
+
+async function recomputeMetrics() {
+  try {
+    const metrics = await getMetrics();
+    await redis.publish('metrics_update', JSON.stringify(metrics));
+    log.info('metrics recomputed');
+  } catch (err) {
+    log.error({ err }, 'metrics recompute failed');
+  }
+}
+
+async function start() {
+  await redis.connect();
+  await runScan();
+  await recomputeMetrics();
+  setInterval(runScan, SCAN_INTERVAL);
+  setInterval(recomputeMetrics, METRICS_INTERVAL);
+}
+
+start().catch((err) => {
+  log.error({ err }, 'failed to start scheduler');
+  process.exit(1);
+});

--- a/packages/svc-scheduler/tsconfig.json
+++ b/packages/svc-scheduler/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add lightweight scheduler service to trigger network scans and metrics recomputation
- expose scheduler intervals via env vars and example file
- run scheduler in docker compose

## Testing
- `npm test`
- `npm run -w @genesisnet/env build`
- `npm run -w @genesisnet/svc-scheduler build` *(fails: Cannot find module 'knex' or its corresponding type declarations)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ade44b10ec832ea5abb0313ef075ab