### PR TITLE
feat(common): add shared data schemas

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,3 +4,4 @@ export * from './http.js';
 export * from './logger.js';
 export * from './request-id.js';
 export * from './activity-log.js';
+export * from './schemas.js';

--- a/packages/common/src/schemas.ts
+++ b/packages/common/src/schemas.ts
@@ -1,0 +1,29 @@
+export type SearchRequest = {
+  query: string;              // "traffic", "weather", etc.
+  max_price?: number;         // optional
+  tags?: string[];            // ["geo","hourly"]
+  budget?: number;            // optional, for purchase decision
+  requester_id: string;       // user or agent id
+};
+
+export type Offer = {
+  offer_id: string;
+  provider_id: string;
+  package_id: string;
+  name: string;
+  price: number;
+  reputation: number;         // from ICP (fallback 0 if not found)
+  data_hash: string;          // integrity marker
+  latency_ms?: number;
+};
+
+export type PurchaseOrder = {
+  offer_id: string;
+  requester_id: string;
+};
+
+export type AgentEvent =
+  | { type: "OFFER_NEW"; payload: Offer }
+  | { type: "TX_SUCCESS"; payload: { tx_id: string; offer_id: string; provider_id: string; amount: number; tx_hash: string } }
+  | { type: "TX_FAILED"; payload: { offer_id: string; reason: string } }
+  | { type: "PROVIDER_ONLINE"; payload: { provider_id: string; node_addr: string; latency_ms?: number } };


### PR DESCRIPTION
## Summary
- define shared SearchRequest, Offer, PurchaseOrder, and AgentEvent types
- export schemas from common package entrypoint

## Testing
- `npm test`
- `npm run lint packages/common/src/schemas.ts packages/common/src/index.ts` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68adec9f30f0832eb2c85dcf62798b49