### PR TITLE
Add transaction and reputation columns

### DIFF
--- a/packages/common/src/activity-log.ts
+++ b/packages/common/src/activity-log.ts
@@ -9,22 +9,22 @@ const db = knex({
 
 /**
  * Write an activity log record.
- * @param action - type of action, e.g. SEARCH, TX, SCAN
- * @param metadata - additional context to store in JSONB metadata column
- * @param userId - optional id of the acting user
+ * @param type - log type, e.g. SEARCH, TX, SCAN
+ * @param meta - additional context to store in JSONB `meta_json` column
+ * @param message - optional human readable message
  */
 export async function logActivity(
-  action: string,
-  metadata: Record<string, unknown> = {},
-  userId?: string,
+  type: string,
+  meta: Record<string, unknown> = {},
+  message = '',
 ): Promise<void> {
   try {
     await db('activity_logs').insert({
-      user_id: userId ?? null,
-      action,
-      metadata,
+      type,
+      message,
+      meta_json: meta,
     });
   } catch (err) {
-    logger.error({ err, action }, 'failed to write activity log');
+    logger.error({ err, type }, 'failed to write activity log');
   }
 }

--- a/packages/db/migrations/003_add_tx_reputation_activity_logs.js
+++ b/packages/db/migrations/003_add_tx_reputation_activity_logs.js
@@ -1,0 +1,36 @@
+/* eslint-disable */
+exports.up = async function (knex) {
+  await knex.schema.alterTable('transactions', (t) => {
+    t.string('tx_id').unique();
+    t.string('requester_id');
+  });
+
+  await knex.schema.alterTable('providers', (t) => {
+    t.integer('reputation').defaultTo(0);
+  });
+
+  await knex.schema.alterTable('activity_logs', (t) => {
+    t.renameColumn('action', 'type');
+    t.renameColumn('metadata', 'meta_json');
+    t.text('message');
+    t.dropColumn('user_id');
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable('activity_logs', (t) => {
+    t.uuid('user_id');
+    t.renameColumn('type', 'action');
+    t.renameColumn('meta_json', 'metadata');
+    t.dropColumn('message');
+  });
+
+  await knex.schema.alterTable('providers', (t) => {
+    t.dropColumn('reputation');
+  });
+
+  await knex.schema.alterTable('transactions', (t) => {
+    t.dropColumn('tx_id');
+    t.dropColumn('requester_id');
+  });
+};


### PR DESCRIPTION
## Summary
- add migration to track tx ids, requester ids, provider reputation, and enhanced activity logs
- update activity log helper to use new type/message/meta_json fields

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68adeed620dc832ebc12297a943eba6a