### PR TITLE
feat: add minimal ICP canister and client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,6 @@ JWT_SECRET=change-me
 
 # ICP canister identifiers
 ICP_LEDGER_CANISTER_ID=
-ICP_REPUTATION_CANISTER_ID=
 ICP_HOST=http://localhost:4943
 
 # Environment

--- a/icp/src/ledger/candid.did
+++ b/icp/src/ledger/candid.did
@@ -1,31 +1,23 @@
 // Candid interface untuk canister ledger GenesisNet
-type TxInput = record {
-  provider_id : text;
-  requester_id : text;
-  price       : nat64;
-  data_hash   : text;
-};
 
-type Transaction = record {
-  id          : nat;
-  provider_id : text;
-  requester_id: text;
-  price       : nat64;
-  data_hash   : text;
-  timestamp   : int;
+// Input transaksi yang dicatat
+// tx_id: ID transaksi dari sistem eksternal
+// provider_id: penyedia layanan yang terlibat
+// amount: jumlah pembayaran (dalam e8s ICP)
+// ts: timestamp (epoch seconds atau miliseconds)
+// data_hash: hash dari data yang dipertukarkan
+
+type TxInput = record {
+  tx_id      : text;
+  provider_id: text;
+  amount     : nat64;
+  ts         : int;
+  data_hash  : text;
 };
 
 service : {
-  // ==== Transaksi & Log ====
-  log_transaction : (TxInput) -> (nat);
-  get_transactions: () -> (vec Transaction) query;
-  get_logs_since  : (nat) -> (vec Transaction) query;
-
-  // ==== Reputasi ====
-  get_reputation  : (text) -> (nat) query;
-  update_reputation : (text, int) -> (nat);   // delta (+/-)
-  set_reputation  : (text, nat) -> (nat);
-
-  // ==== Util ====
-  reset_all : () -> ();   // dev only (local)
-}
+  // ==== Transaksi & Reputasi ====
+  log_transaction   : (TxInput) -> (nat);
+  get_reputation    : (text) -> (nat) query;
+  update_reputation : (text, int) -> (nat); // delta (+/-)
+};

--- a/icp/src/ledger/lib.mo
+++ b/icp/src/ledger/lib.mo
@@ -1,0 +1,68 @@
+import Array "mo:base/Array";
+import Int "mo:base/Int";
+import Nat "mo:base/Nat";
+import Text "mo:base/Text";
+
+actor {
+  public type TxInput = {
+    tx_id : Text;
+    provider_id : Text;
+    amount : Nat;
+    ts : Int;
+    data_hash : Text;
+  };
+
+  public type Transaction = {
+    id : Nat;
+    tx_id : Text;
+    provider_id : Text;
+    amount : Nat;
+    ts : Int;
+    data_hash : Text;
+  };
+
+  stable var nextId : Nat = 0;
+  stable var transactions : [Transaction] = [];
+  stable var reputations : [(Text, Nat)] = [];
+
+  public func log_transaction(tx : TxInput) : async Nat {
+    let id = nextId;
+    nextId += 1;
+    let record : Transaction = {
+      id;
+      tx_id = tx.tx_id;
+      provider_id = tx.provider_id;
+      amount = tx.amount;
+      ts = tx.ts;
+      data_hash = tx.data_hash;
+    };
+    transactions := Array.append(transactions, [record]);
+    ignore update_reputation(tx.provider_id, 1);
+    id
+  };
+
+  public query func get_reputation(provider_id : Text) : async Nat {
+    switch (Array.find<(Text,Nat)>(reputations, func (p) { p.0 == provider_id })) {
+      case (?pair) pair.1;
+      case null 0;
+    }
+  };
+
+  public func update_reputation(provider_id : Text, delta : Int) : async Nat {
+    let current : Nat = await get_reputation(provider_id);
+    let nextInt = Int.fromNat(current) + delta;
+    let nextNat = if (nextInt < 0) 0 else Nat.fromInt(nextInt);
+
+    var updated = false;
+    reputations := Array.map<(Text,Nat), (Text,Nat)>(reputations, func (p) {
+      if (p.0 == provider_id) {
+        updated := true;
+        (provider_id, nextNat)
+      } else p
+    });
+    if (!updated) {
+      reputations := Array.append(reputations, [(provider_id, nextNat)]);
+    };
+    nextNat
+  };
+}

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -26,7 +26,6 @@ const schema = z.object({
   REDIS_URL: z.string().url().default('redis://redis:6379/0'),
   JWT_SECRET: z.string().default('change-me'),
   ICP_LEDGER_CANISTER_ID: z.string().optional(),
-  ICP_REPUTATION_CANISTER_ID: z.string().optional(),
   ICP_HOST: z.string().url().default('http://localhost:4943'),
 });
 

--- a/packages/svc-tx/src/lib/icp.ts
+++ b/packages/svc-tx/src/lib/icp.ts
@@ -7,14 +7,16 @@ const agent = new HttpAgent({ host: env.ICP_HOST });
 const ledgerIdl = ({ IDL }: { IDL: typeof import('@dfinity/candid').IDL }) =>
   IDL.Service({
     log_transaction: IDL.Func([
-      IDL.Record({ txId: IDL.Text, amount: IDL.Nat64 }),
-    ], [], []),
-  });
-
-const reputationIdl = ({ IDL }: { IDL: typeof import('@dfinity/candid').IDL }) =>
-  IDL.Service({
-    get_reputation: IDL.Func([IDL.Text], [IDL.Int], ['query']),
-    update_reputation: IDL.Func([IDL.Text, IDL.Int], [], []),
+      IDL.Record({
+        tx_id: IDL.Text,
+        provider_id: IDL.Text,
+        amount: IDL.Nat64,
+        ts: IDL.Int,
+        data_hash: IDL.Text,
+      }),
+    ], [IDL.Nat], []),
+    get_reputation: IDL.Func([IDL.Text], [IDL.Nat], ['query']),
+    update_reputation: IDL.Func([IDL.Text, IDL.Int], [IDL.Nat], []),
   });
 
 const ledgerActor = env.ICP_LEDGER_CANISTER_ID
@@ -24,24 +26,29 @@ const ledgerActor = env.ICP_LEDGER_CANISTER_ID
     })
   : null;
 
-const reputationActor = env.ICP_REPUTATION_CANISTER_ID
-  ? Actor.createActor(reputationIdl, {
-      agent,
-      canisterId: env.ICP_REPUTATION_CANISTER_ID,
-    })
-  : null;
-
-export async function logTransaction(txId: string, amount: bigint) {
+export async function logTransaction(
+  txId: string,
+  providerId: string,
+  amount: bigint,
+  ts: bigint,
+  dataHash: string,
+) {
   if (!ledgerActor) throw new Error('ICP ledger canister not configured');
-  return (ledgerActor as any).log_transaction({ txId, amount });
+  return (ledgerActor as any).log_transaction({
+    tx_id: txId,
+    provider_id: providerId,
+    amount,
+    ts,
+    data_hash: dataHash,
+  });
 }
 
-export async function getReputation(userId: string): Promise<bigint> {
-  if (!reputationActor) throw new Error('ICP reputation canister not configured');
-  return (reputationActor as any).get_reputation(userId);
+export async function getReputation(providerId: string): Promise<bigint> {
+  if (!ledgerActor) throw new Error('ICP ledger canister not configured');
+  return (ledgerActor as any).get_reputation(providerId);
 }
 
-export async function updateReputation(userId: string, delta: bigint) {
-  if (!reputationActor) throw new Error('ICP reputation canister not configured');
-  return (reputationActor as any).update_reputation(userId, delta);
+export async function updateReputation(providerId: string, delta: bigint) {
+  if (!ledgerActor) throw new Error('ICP ledger canister not configured');
+  return (ledgerActor as any).update_reputation(providerId, delta);
 }

--- a/packages/svc-tx/src/routes/tx.ts
+++ b/packages/svc-tx/src/routes/tx.ts
@@ -69,7 +69,13 @@ router.post('/:id/mark-paid', async (req, res) => {
     log.error({ err }, 'activity log failed'),
   );
   try {
-    await logTransaction(tx.id, BigInt(tx.amount));
+    await logTransaction(
+      tx.id,
+      tx.seller_id,
+      BigInt(tx.amount),
+      BigInt(Date.now()),
+      tx.memo || '',
+    );
   } catch (err) {
     log.error({ err }, 'icp log_transaction failed');
   }


### PR DESCRIPTION
## Summary
- implement Motoko ledger canister with transaction logging and reputation API
- expose matching Node client bindings and update tx route
- streamline environment config for single ledger canister

## Testing
- `npm test`
- `npm run -w svc-tx check` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68adf075ba9c832e96162e9c4411d386