### PR TITLE
feat: add ICP client adapter

### DIFF
--- a/packages/blockchain-service/package.json
+++ b/packages/blockchain-service/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@genesisnet/blockchain-service",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@dfinity/agent": "^0.20.2",
+    "@dfinity/candid": "^0.20.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2",
+    "@types/node": "^20.19.11"
+  }
+}

--- a/packages/blockchain-service/src/icp.ts
+++ b/packages/blockchain-service/src/icp.ts
@@ -1,0 +1,27 @@
+import { HttpAgent, Actor } from "@dfinity/agent";
+import idlFactory from "./reputation.idl.js"; // hasil dfx generate
+
+const canisterId = process.env.ICP_CANISTER_ID!;
+
+const agent = new HttpAgent({ host: process.env.ICP_HOST ?? "https://icp0.io" });
+// if dev: await agent.fetchRootKey();
+
+export const icp = Actor.createActor(idlFactory, { agent, canisterId });
+
+export async function getReputation(providerId: string): Promise<number> {
+  return Number(await (icp as any).get_reputation(providerId));
+}
+
+export async function logTx(tx: { tx_id: string; provider_id: string; amount: number; data_hash: string; ts: bigint; }) {
+  return (icp as any).log_transaction(
+    tx.tx_id,
+    tx.provider_id,
+    BigInt(Math.floor(tx.amount * 1e8)),
+    tx.ts,
+    tx.data_hash
+  );
+}
+
+export async function bumpReputation(providerId: string, delta = 1) {
+  return (icp as any).update_reputation(providerId, BigInt(delta));
+}

--- a/packages/blockchain-service/src/reputation.idl.js
+++ b/packages/blockchain-service/src/reputation.idl.js
@@ -1,0 +1,18 @@
+export const idlFactory = ({ IDL }) =>
+  IDL.Service({
+    log_transaction: IDL.Func(
+      [IDL.Text, IDL.Text, IDL.Nat64, IDL.Int, IDL.Text],
+      [IDL.Nat],
+      []
+    ),
+    get_reputation: IDL.Func([IDL.Text], [IDL.Nat], ["query"]),
+    update_reputation: IDL.Func(
+      [IDL.Text, IDL.Int],
+      [IDL.Nat],
+      []
+    ),
+  });
+
+export const init = ({ IDL }) => { return []; };
+
+export default idlFactory;

--- a/packages/blockchain-service/tsconfig.json
+++ b/packages/blockchain-service/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "module": "NodeNext"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add new blockchain-service package with ICP reputation client
- include generated IDL for reputation canister

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden fetching @dfinity/agent)*

------
https://chatgpt.com/codex/tasks/task_e_68adf1bd9c4c832e869a1f62b1c6fd49