### PR TITLE
feat: add agent gateway routes

### DIFF
--- a/packages/svc-api-gateway/package.json
+++ b/packages/svc-api-gateway/package.json
@@ -16,7 +16,11 @@
     "express": "^4.19.2",
     "@genesisnet/common": "^0.1.0",
     "cors": "^2.8.5",
-    "http-proxy-middleware": "^2.0.6"
+    "http-proxy-middleware": "^2.0.6",
+    "axios": "^1.6.8",
+    "pg": "^8.11.5",
+    "redis": "^4.6.12",
+    "@genesisnet/blockchain-service": "^0.1.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.23",

--- a/packages/svc-api-gateway/src/db.ts
+++ b/packages/svc-api-gateway/src/db.ts
@@ -1,0 +1,4 @@
+import { Pool } from 'pg';
+import { env } from '@genesisnet/env';
+
+export const pool = new Pool({ connectionString: env.DATABASE_URL });

--- a/packages/svc-api-gateway/src/routes/agents.ts
+++ b/packages/svc-api-gateway/src/routes/agents.ts
@@ -1,0 +1,63 @@
+import { Router } from 'express';
+import type { AgentEvent } from '@genesisnet/common/src/schemas.js';
+import { io } from '../ws.js';
+import { pool } from '../db.js';
+import { bumpReputation } from '@genesisnet/blockchain-service/src/icp.js';
+
+const r = Router();
+
+// webhook dari semua Agent
+r.post('/events', async (req, res) => {
+  const event = req.body as AgentEvent;
+
+  try {
+    if (event.type === 'OFFER_NEW') {
+      await pool.query(
+        'INSERT INTO activity_logs(type,message,meta_json) VALUES($1,$2,$3)',
+        ['OFFER', `Offer from provider ${event.payload.provider_id}`, event.payload],
+      );
+      io.emit('activity_log', { type: 'OFFER', payload: event.payload });
+      io.emit('search_results', [event.payload]);
+    }
+
+    if (event.type === 'TX_SUCCESS') {
+      const { tx_id, offer_id, provider_id, amount, tx_hash } = event.payload;
+      await pool.query(
+        "UPDATE transactions SET status='CONFIRMED', tx_hash=$1 WHERE tx_id=$2",
+        [tx_hash, tx_id],
+      );
+      await bumpReputation(provider_id, 1);
+      // await logTx({ tx_id, provider_id, amount, data_hash: '...', ts: BigInt(Date.now()) });
+
+      io.emit('activity_log', { type: 'TX', payload: event.payload });
+      io.emit('metrics_update');
+    }
+
+    if (event.type === 'TX_FAILED') {
+      await pool.query(
+        "UPDATE transactions SET status='FAILED' WHERE id=(SELECT id FROM transactions WHERE offer_id=$1 ORDER BY created_at DESC LIMIT 1)",
+        [event.payload.offer_id],
+      );
+      io.emit('activity_log', { type: 'TX_FAILED', payload: event.payload });
+      io.emit('metrics_update');
+    }
+
+    if (event.type === 'PROVIDER_ONLINE') {
+      const { provider_id, node_addr, latency_ms } = event.payload;
+      await pool.query(
+        `INSERT INTO network_nodes(addr, is_online, latency_ms, updated_at)
+         VALUES($1,true,$2,NOW())
+         ON CONFLICT (addr) DO UPDATE SET is_online=true, latency_ms=$2, updated_at=NOW()`,
+        [node_addr, latency_ms ?? null],
+      );
+      io.emit('network_update', event.payload);
+    }
+
+    res.json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'event_handling_failed' });
+  }
+});
+
+export default r;

--- a/packages/svc-api-gateway/src/routes/search.ts
+++ b/packages/svc-api-gateway/src/routes/search.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express';
+import type { SearchRequest } from '@genesisnet/common/src/schemas.js';
+import axios from 'axios';
+import { pool } from '../db.js';
+import { env } from '@genesisnet/env';
+
+const r = Router();
+
+// trigger Requester Agent
+r.post('/', async (req, res) => {
+  const body = req.body as SearchRequest;
+
+  await pool.query(
+    'INSERT INTO activity_logs(type,message,meta_json) VALUES($1,$2,$3)',
+    ['SEARCH', `Search ${body.query}`, body],
+  );
+
+  await axios.post(`${env.REQUESTER_AGENT_URL}/search`, body);
+
+  res.status(202).json({ status: 'searching' });
+});
+
+export default r;

--- a/packages/svc-api-gateway/src/routes/tx.ts
+++ b/packages/svc-api-gateway/src/routes/tx.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import type { PurchaseOrder } from '@genesisnet/common/src/schemas.js';
+import axios from 'axios';
+import crypto from 'node:crypto';
+import { pool } from '../db.js';
+import { env } from '@genesisnet/env';
+
+const r = Router();
+
+r.post('/initiate', async (req, res) => {
+  const body = req.body as PurchaseOrder;
+
+  const txId = crypto.randomUUID();
+  await pool.query(
+    "INSERT INTO transactions(tx_id, status, amount, provider_id, user_id, package_id, created_at) VALUES($1,'PENDING',NULL,NULL,$2,NULL,NOW())",
+    [txId, body.requester_id],
+  );
+
+  await axios.post(`${env.REQUESTER_AGENT_URL}/purchase`, { ...body, tx_id: txId });
+
+  res.json({ tx_id: txId, status: 'PENDING' });
+});
+
+export default r;

--- a/packages/svc-api-gateway/src/ws.ts
+++ b/packages/svc-api-gateway/src/ws.ts
@@ -1,0 +1,10 @@
+import { createClient } from 'redis';
+import { env } from '@genesisnet/env';
+
+const pub = createClient({ url: env.REDIS_URL });
+await pub.connect();
+
+export const io = {
+  emit: (channel: string, payload?: unknown) =>
+    pub.publish(channel, JSON.stringify(payload)),
+};


### PR DESCRIPTION
## Summary
- add database and redis helpers for API gateway
- implement agent event, search, and transaction routes
- register new routes in gateway index

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dfinity%2fagent)*
- `npm test -w @genesisnet/svc-api-gateway`
- `npm run -w @genesisnet/svc-api-gateway check` *(fails: see TypeScript errors in /tmp/check.log)*

------
https://chatgpt.com/codex/tasks/task_e_68adf402c850832ea7cbb78e935eac42