### PR TITLE
feat: add gateway security

### DIFF
--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -25,6 +25,8 @@ const schema = z.object({
   DATABASE_URL: z.string().url().default('postgres://postgres:postgres@postgres:5432/genesisnet'),
   REDIS_URL: z.string().url().default('redis://redis:6379/0'),
   JWT_SECRET: z.string().default('change-me'),
+  AGENT_SHARED_SECRET: z.string().optional(),
+  AGENT_IP: z.string().optional(),
   ICP_LEDGER_CANISTER_ID: z.string().optional(),
   ICP_HOST: z.string().url().default('http://localhost:4943'),
 });

--- a/packages/svc-api-gateway/package.json
+++ b/packages/svc-api-gateway/package.json
@@ -20,7 +20,8 @@
     "axios": "^1.6.8",
     "pg": "^8.11.5",
     "redis": "^4.6.12",
-    "@genesisnet/blockchain-service": "^0.1.0"
+    "@genesisnet/blockchain-service": "^0.1.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.23",


### PR DESCRIPTION
## Summary
- protect `/api/tx/*` and `/api/data/search` with simple JWT verification
- validate agent webhook payloads and restrict access via shared secret or IP
- expose AGENT_SHARED_SECRET and AGENT_IP env variables

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ae00737380832ea5408aab717a7770