### PR TITLE
feat: add tx status endpoint and docs

### DIFF
--- a/agents/requester/app.py
+++ b/agents/requester/app.py
@@ -31,7 +31,7 @@ def search(body: SearchRequest):
 
 @app.post("/purchase")
 def purchase(payload: dict):
-    # TODO: kirim purchase via uAgents; contoh alur lengkap:
+    # TODO: kirim purchase via uAgents; mock alur:
     processing_event = {
         "type": "TX_PROCESSING",
         "payload": {
@@ -44,15 +44,24 @@ def purchase(payload: dict):
     }
     requests.post(f"{GATEWAY}/agents/events", json=processing_event)
 
-    tx_event = {
-        "type": "TX_SUCCESS",
-        "payload": {
-            "tx_id": payload["tx_id"],
-            "offer_id": payload["offer_id"],
-            "provider_id": "prov-1",
-            "amount": 3.1,
-            "tx_hash": "0xDUMMY",
-        },
-    }
+    if payload.get("fail"):
+        tx_event = {
+            "type": "TX_FAILED",
+            "payload": {
+                "offer_id": payload["offer_id"],
+                "reason": "mock failure",
+            },
+        }
+    else:
+        tx_event = {
+            "type": "TX_SUCCESS",
+            "payload": {
+                "tx_id": payload["tx_id"],
+                "offer_id": payload["offer_id"],
+                "provider_id": "prov-1",
+                "amount": 3.1,
+                "tx_hash": "0xDUMMY",
+            },
+        }
     requests.post(f"{GATEWAY}/agents/events", json=tx_event)
     return {"status": "ok"}

--- a/docs/FE.md
+++ b/docs/FE.md
@@ -1,0 +1,31 @@
+# Frontend Integration
+
+## Transaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant GW as Gateway
+    participant RA as Requester Agent
+    FE->>GW: POST /api/tx/initiate
+    GW-->>FE: { tx_id, status: "PENDING" }
+    GW->>RA: POST /purchase
+    RA-->>GW: AgentEvent (TX_SUCCESS/TX_FAILED)
+    GW-->>FE: WebSocket metrics & tx update
+```
+
+## Sample Agent Event
+
+```json
+{
+  "type": "TX_SUCCESS",
+  "payload": {
+    "tx_id": "123",
+    "offer_id": "off-1",
+    "provider_id": "prov-1",
+    "amount": 3.1,
+    "tx_hash": "0xDUMMY"
+  }
+}
+```
+

--- a/packages/svc-api-gateway/src/index.ts
+++ b/packages/svc-api-gateway/src/index.ts
@@ -21,7 +21,6 @@ app.get('/ready', (req, res) => res.json({ ready: true }));
 
 app.use('/agents', agentsRouter);
 app.use('/search', searchRouter);
-app.use('/tx', txRouter);
 
 function verifyJWT(req: Request, res: Response, next: NextFunction) {
   const auth = req.headers.authorization;
@@ -49,7 +48,7 @@ function verifyJWT(req: Request, res: Response, next: NextFunction) {
   }
 }
 
-app.use('/api/tx', verifyJWT);
+app.use('/api/tx', verifyJWT, txRouter);
 app.use('/api/data/search', verifyJWT);
 
 // proxy routes to internal services
@@ -57,7 +56,6 @@ const proxies = [
   { path: '/api/dashboard', target: `http://localhost:${env.METRICS_PORT}`, rewrite: '/dashboard' },
   { path: '/api/data', target: `http://localhost:${env.SEARCH_PORT}` },
   { path: '/api/network', target: `http://localhost:${env.NETWORK_PORT}` },
-  { path: '/api/tx', target: `http://localhost:${env.TX_PORT}` },
   { path: '/api/reputation', target: `http://localhost:${env.REPUTATION_PORT}` },
 ];
 

--- a/packages/svc-api-gateway/src/routes/agents.ts
+++ b/packages/svc-api-gateway/src/routes/agents.ts
@@ -4,8 +4,9 @@ import { pool } from '../db.js';
 import { bumpReputation } from '@genesisnet/blockchain-service/src/icp.js';
 import { env } from '@genesisnet/env';
 import { z } from 'zod';
+import type { AgentEvent, Offer } from '@genesisnet/common/src/schemas.js';
 
-const offerSchema = z.object({
+const offerSchema: z.ZodType<Offer> = z.object({
   offer_id: z.string(),
   provider_id: z.string(),
   package_id: z.string(),
@@ -16,7 +17,7 @@ const offerSchema = z.object({
   latency_ms: z.number().optional(),
 });
 
-const agentEventSchema = z.discriminatedUnion('type', [
+const agentEventSchema: z.ZodType<AgentEvent> = z.discriminatedUnion('type', [
   z.object({ type: z.literal('OFFER_NEW'), payload: offerSchema }),
   z.object({
     type: z.literal('TX_PROCESSING'),
@@ -51,8 +52,6 @@ const agentEventSchema = z.discriminatedUnion('type', [
     }),
   }),
 ]);
-
-type AgentEvent = z.infer<typeof agentEventSchema>;
 
 const r = Router();
 

--- a/packages/svc-api-gateway/src/routes/tx.ts
+++ b/packages/svc-api-gateway/src/routes/tx.ts
@@ -21,4 +21,16 @@ r.post('/initiate', async (req, res) => {
   res.json({ tx_id: txId, status: 'PENDING' });
 });
 
+r.get('/status', async (req, res) => {
+  const { tx_id } = req.query as { tx_id?: string };
+  if (!tx_id) {
+    return res.status(400).json({ error: 'missing_tx_id' });
+  }
+  const { rows } = await pool.query('SELECT status FROM transactions WHERE tx_id=$1', [tx_id]);
+  if (!rows.length) {
+    return res.status(404).json({ error: 'not_found' });
+  }
+  res.json({ tx_id, status: rows[0].status });
+});
+
 export default r;


### PR DESCRIPTION
## Summary
- expose JWT protected /api/tx routes with status lookup
- type gateway agent events with shared schemas
- requester agent mock now emits TX_SUCCESS or TX_FAILED events
- add frontend sequence diagram and event sample

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ae06ee5774832e95c6cfd6283e09ef